### PR TITLE
Refactor/article body

### DIFF
--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -7,6 +7,8 @@ import CommentContainer from './CommentContainer';
 import agent from '../../agent';
 import { ARTICLE_PAGE_LOADED, ARTICLE_PAGE_UNLOADED } from '../../constants/actionTypes';
 
+import styles from './index.module.css';
+
 const mapStateToProps = state => ({
   ...state.article,
   currentUser: state.common.currentUser
@@ -54,7 +56,7 @@ const Article = ({ article, commentErrors, comments, currentUser, match, onLoad,
       <div className="container page">
         <div className="row article-content">
           <div className="col-xs-12">
-            <div dangerouslySetInnerHTML={markup}></div>
+            <div className={`${styles.rawMarkup}`} dangerouslySetInnerHTML={markup}></div>
               <ul className="tag-list">
                 {
                   article.tagList.map(tag => {

--- a/src/components/Article/index.module.css
+++ b/src/components/Article/index.module.css
@@ -1,0 +1,98 @@
+.rawMarkup {
+  margin: 0;
+  padding: 0;
+  background-color: var(--background-primary);
+  font-size: 20px;
+  line-height: 28px;
+  color: var(--text-primary);
+}
+
+.rawMarkup h1,
+.rawMarkup h2,
+.rawMarkup h3,
+.rawMarkup h4,
+.rawMarkup h5,
+.rawMarkup h6 {
+  margin: 0 0 32px;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
+.rawMarkup h1 {
+  font-size: 80px;
+  line-height: 88px;
+}
+
+.rawMarkup h2 {
+  font-size: 40px;
+  line-height: 48px;
+}
+
+.rawMarkup h3 {
+  font-size: 32px;
+  line-height: 40px;
+}
+
+.rawMarkup h4,
+.rawMarkup h5,
+.rawMarkup h6 {
+  font-size: 24px;
+  line-height: 32px;
+}
+
+.rawMarkup p {
+  margin: 0 0 32px;
+  padding: 0;
+}
+
+.rawMarkup p img {
+  margin: 0;
+}
+
+.rawMarkup img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 32px;
+  vertical-align: middle;
+  border-radius: 8px;
+  background-color: var(--input-background);
+}
+
+.rawMarkup q,
+.rawMarkup blockquote {
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: normal;
+  font-style: normal;
+  background-color: var(--background-secondary);
+}
+
+.rawMarkup blockquote {
+  margin: 0 0 32px;
+  padding: 32px;
+}
+
+.rawMarkup a,
+.rawMarkup a:visited {
+  color: var(--text-secondary);
+  text-decoration: underline;
+}
+
+.rawMarkup a:hover,
+.rawMarkup a:focus {
+  color: var(--text-accent);
+}
+
+.rawMarkup a:active {
+  color: var(--text-success);
+}
+
+.rawMarkup i,
+.rawMarkup em {
+  font-style: normal;
+}
+
+.rawMarkup b,
+.rawMarkup strong {
+  font-weight: normal;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ import { ConnectedRouter } from 'react-router-redux';
 
 import App from './components/App';
 
+import './common.css';
+import './theme.css';
+
 ReactDOM.render((
   <Provider store={store}>
     <ConnectedRouter history={history}>


### PR DESCRIPTION
В тело статьи попадает разметка, генерируемая **Markdown** ([ссылка на Wiki](https://ru.wikipedia.org/wiki/Markdown)), поэтому навесил новый класс на блок со сгенерированной разметкой и описал стили по тегам внутри этого компонента.
```css
.className h1  { ... }
.className p   { ... }
.className img { ... }
/* и так далее */
```
Так как в макете отсутствуют какие-либо начертания шрифтов кроме `font-weight: 400` и `font-style: normal`, то постарался предусмотреть это в базовых тегах.


Взял на себя смелость импортировать **theme.css** в главный **index.js**. Иначе нельзя было использовать переменные с цветами.